### PR TITLE
when array_len is nil, do not run dotimes...

### DIFF
--- a/src/geneus/generate.py
+++ b/src/geneus/generate.py
@@ -264,8 +264,10 @@ def write_slot_argument(s, field):
         s.write('((:%s __%s) %s)'%(var, var, field_initvalue(field)))
     else:
         if field.is_array:
-            len = field.array_len or 0
-            s.write('((:%s __%s) (let (r) (dotimes (i %s) (push (instance %s :init) r)) r))'%(var, var, len, field_type(field))) ## FIX??? need to use len = f.array_len or 0
+            if field.array_len:
+                s.write('((:%s __%s) (let (r) (dotimes (i %s) (push (instance %s :init) r)) r))'%(var, var, field.array_len, field_type(field)))
+            else:
+                s.write('((:%s __%s) ())'%(var, var))
         else:
             s.write('((:%s __%s) (instance %s :init))'%(var, var, field_type(field)))
 


### PR DESCRIPTION
to avoid consuing like https://github.com/jsk-ros-pkg/jsk_roseus/issues/544

Message like

```
MultiArrayDimension[] dim # Array of dimension properties
uint32 data_offset        # padding elements at front of data
```

is converted to 

```
(defmethod std_msgs::MultiArrayLayout
  (:init
   (&key
    ((:dim __dim) (let (r) (dotimes (i 0) (push (instance std_msgs::MultiArrayDimension :init) r)) r)) 
;;何もしていない
    ((:data_offset __data_offset) 0)
    )
```

which seems we can write something like

```
(instnace std_msgs::MultiArrayLayout :init :dim 10)
```

but this is not correct, we should write something like

```
(instance std_msgs::MultiArrayLayout :init :dim (let (r) (dotimes (i 10) (push (instance std_msgs::MultiArrayDimension :init) r))))
```