### PR TITLE
update write_accessors in generate.py for bool

### DIFF
--- a/src/geneus/generate.py
+++ b/src/geneus/generate.py
@@ -307,9 +307,12 @@ def write_accessors(s, spec):
             s.write('(:%s'%field.name)
             var = '_%s'%field.name
             with Indent(s, inc=1):
-                if field.is_builtin:
+                if field.is_builtin and field.type!="bool":
                     s.write('(&optional _%s)'%var)
                     s.write('(if _%s (setq %s _%s)) %s)'%(var,var,var,var))
+                elif field.type=="bool":
+                    s.write('(&optional (_%s nil _%s_supplied_p))'%(var,var))
+                    s.write('(if _%s_supplied_p (setq %s _%s)) %s)'%(var,var,var,var))
                 else:
                     s.write('(&rest _%s)'%var)
                     s.write('(if (keywordp (car _%s))'%var)


### PR DESCRIPTION
既出でしたら申し訳ありません。
```
1.irteusgl$ setq a (instance std_msgs::bool :init)
#<std_msgs::bool #X4dc8028>
2.irteusgl$ send a :data
nil
3.irteusgl$ send a :data t
t
4.irteusgl$ send a :data nil 
t
5.irteusgl$ send a :data
t
```
generate.pyによって作成されるeuslispのコードでは、引数にnilをいれるとデータが変化しない仕様になっており、上記のようにデータをnilに変更することができません。generate.pyによって下記のようなコードが生成されるためです。
```
(:data
   (&optional __data)
   (if __data (setq _data __data)) _data)
```
引数にnilを入れてもデータが変化しない仕様にはメリットもありますが、データの型がboolだった場合に限っては、一度trueにすると二度とfalseに戻せなくなってしまうというデメリットが大きいと感じます。データの型がboolだった場合に限り下記のようなコードを生成するようにしたいと思いwrite_accessors関数を書き換えてみたのですが、いかがでしょうか。
```
(:data
   (&rest __data)
   (if __data (setq _data (car __data))) _data)
```