### PR TITLE
[generate.py] Fix bug of write_constants

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(geneus)
-find_package(catkin REQUIRED COMPONENTS genmsg std_msgs message_generation)
+find_package(catkin REQUIRED COMPONENTS genmsg message_generation)
 
 add_message_files(FILES testMsg.msg)
 
 catkin_python_setup()
-
-generate_messages(DEPENDENCIES std_msgs)
 
 catkin_package(
   CATKIN_DEPENDS genmsg

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(geneus)
-find_package(catkin REQUIRED COMPONENTS genmsg)
+find_package(catkin REQUIRED COMPONENTS genmsg std_msgs message_generation)
+
+add_message_files(FILES testMsg.msg)
+
+catkin_python_setup()
+
+generate_messages(DEPENDENCIES std_msgs)
 
 catkin_package(
   CATKIN_DEPENDS genmsg
@@ -18,4 +24,7 @@ file(WRITE ${CATKIN_DEVEL_PREFIX}/share/roseus/rospack_nosubdirs "")
 install(FILES ${CATKIN_DEVEL_PREFIX}/share/roseus/rospack_nosubdirs
   DESTINATION share/roseus)
 
-catkin_python_setup()
+if(CATKIN_ENABLE_TESTING)
+  find_package(catkin REQUIRED COMPONENTS rostest)
+  add_rostest(test/test-genmsg.test)
+endif()

--- a/msg/testMsg.msg
+++ b/msg/testMsg.msg
@@ -1,0 +1,2 @@
+bool FALSE_FLAG=0
+bool TRUE_FLAG=1

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,7 @@
   <run_depend>genmsg</run_depend>
 
   <test_depend>message_generation</test_depend>
-  <test_depend>std_msgs</test_depend>
+  <test_depend>roseus</test_depend>
 
   <export>
     <message_generator>eus</message_generator>

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,9 @@
 
   <run_depend>genmsg</run_depend>
 
+  <test_depend>message_generation</test_depend>
+  <test_depend>std_msgs</test_depend>
+
   <export>
     <message_generator>eus</message_generator>
   </export>

--- a/src/geneus/generate.py
+++ b/src/geneus/generate.py
@@ -670,7 +670,7 @@ def write_constants(s, spec):
             if c.type == 'string':
                 s.write('(defconstant %s::%s::*%s* "%s")'%(spec.package, spec.actual_name, c.name.upper(), c.val.replace('"', '\\"')))
             elif c.type == 'bool':
-                s.write('(defconstant %s::%s::*%s* %s)'%(spec.package, spec.actual_name, c.name.upper(), "t" if c.val == "True" else "nil"))
+                s.write('(defconstant %s::%s::*%s* %s)'%(spec.package, spec.actual_name, c.name.upper(), "t" if c.val == True else "nil"))
             else:
                 s.write('(defconstant %s::%s::*%s* %s)'%(spec.package, spec.actual_name, c.name.upper(), c.val))
 

--- a/test/test-genmsg.l
+++ b/test/test-genmsg.l
@@ -1,0 +1,15 @@
+#!/usr/bin/env roseus
+(require :unittest "lib/llib/unittest.l")
+(ros::load-ros-manifest "geneus")
+
+(init-unit-test)
+
+(deftest test-generate-message
+  (let ((msg (instance geneus::testMsg :init))) 
+    (assert geneus::testMsg::*TRUE_FLAG*
+            (format nil "true flag value: ~A" geneus::testMsg::*TRUE_FLAG*))
+    (assert (null geneus::testMsg::*FALSE_FLAG*)
+            (format nil "false value: ~A" geneus::testMsg::*FALSE_FLAG*))))
+
+(run-all-tests)
+(exit)

--- a/test/test-genmsg.test
+++ b/test/test-genmsg.test
@@ -1,0 +1,5 @@
+<launch>
+  <!-- test node -->
+  <test test-name="generate_msg_test" pkg="geneus" type="test-genmsg.l"
+	retry="3" time-limit="300"/>
+</launch>


### PR DESCRIPTION
Now, we cannot get a default boolean rosmsg value.

For example, if create `test_msg.msg`  message in `eus_test_msg` package like below, 
```
bool flag
bool FLAG=1
```

I always get `nil` as a default value even though I set `FLAG=1`.
```
1.irteusgl$ ros::load-ros-manifest "eus_msg_test"           
t                                                                               
2.irteusgl$ setq msg (instance eus_msg_test::test_msg :init)                    
#<eus_msg_test::test_msg #X6396318>                                                                                                                        
3.irteusgl$ send msg :flag eus_msg_test::test_msg::*flag*                       
nil
```

The cause of this problem is this line.
https://github.com/jsk-ros-pkg/geneus/blob/a97101f8ce8aa95bbaa9dee1586bcfccc9abf125/src/geneus/generate.py#L673

This line's "True" should not be string value.
```
"t" if c.val == "True" else "nil"
```
after fix like below, I got correct boolean default value.
```
"t" if c.val == True else "nil"
```