### PR TITLE
export geneus as ros2 ament library

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,22 +6,29 @@
   <name>geneus</name>
   <version>3.0.0</version>
   <description>
-  EusLisp ROS message and service generators.
+    EusLisp ROS message and service generators for ROS 1.
+    EusLisp ROS message and service typesupport library for ROS 2.
   </description>
   <maintainer email="k-okada@jsk.t.u-tokyo.ac.jp">Kei Okada</maintainer>
+  <maintainer email="obinata@jsk.imi.i.u-tokyo.ac.jp">Yoshiki Obinata</maintainer>
   <license>BSD</license>
 
   <author>Kei Okada</author>
+  <author>Yoshiki Obinata</author>
 
-  <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
+  <buildtool_depend version_gte="0.5.78" condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_python</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
-  <build_depend>genmsg</build_depend>
+  <build_depend condition="$ROS_VERSION == 1">genmsg</build_depend>
+  <exec_depend condition="$ROS_VERSION == 1">genmsg</exec_depend>
+  <test_depend condition="$ROS_VERSION == 2">python3-pytest</test_depend>
 
-  <exec_depend>genmsg</exec_depend>
+  <depend condition="ROS_VERSION == 2">rosidl_adapter</depend>
 
   <export>
-    <message_generator>eus</message_generator>
+    <message_generator condition="$ROS_VERSION == 1">eus</message_generator>
+    <build_type condition="$ROS_VERSION == 2">ament_python</build_type>
   </export>
 </package>

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/geneus
+[install]
+install_scripts=$base/lib/geneus

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,6 @@
 script_dir=$base/lib/geneus
 [install]
 install_scripts=$base/lib/geneus
+[tool:pytest]
+testpaths = test
+addopts = --ignore=test/test_geneus_send_msgs.py

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,45 @@
 
+import os
 from setuptools import setup
-from catkin_pkg.python_setup import generate_distutils_setup
 
-d = generate_distutils_setup(
-    packages=['geneus'],
-    package_dir={'': 'src'},
-    requires=['genmsg']
-)
+if os.getenv("ROS_VERSION", default=1) == '2':
+    from setuptools import find_packages
+    package_name = 'geneus'
 
-setup(**d)
+    setup(
+        name=package_name,
+        version='0.0.0',
+        packages=find_packages(where='src', exclude=['test']),
+        package_dir={'': 'src'},
+        data_files=[
+            ('share/ament_index/resource_index/packages',
+             ['resource/' + package_name]),
+            ('share/' + package_name, ['package.xml']),
+        ],
+        install_requires=['setuptools'],
+        zip_safe=True,
+        maintainer=['Kei Okada', 'Yoshiki Obinata'],
+        maintainer_email=['k-okada@jsk.t.u-tokyo.ac.jp', 'obinata@jsk.imi.i.u-tokyo.ac.jp'],
+        description='EusLisp ROS message and service typesupport library for ROS 2',
+        license='BSD',
+        extras_require={
+            'test': [
+                'pytest',
+            ],
+        },
+        entry_points={
+            'console_scripts': [
+            ],
+        },
+    )
+
+else:
+    from catkin_pkg.python_setup import generate_distutils_setup
+
+    d = generate_distutils_setup(
+        packages=['geneus'],
+        package_dir={'': 'src'},
+        requires=['genmsg']
+    )
+
+    setup(**d)

--- a/src/geneus/__init__.py
+++ b/src/geneus/__init__.py
@@ -29,4 +29,6 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from . geneus_main import *
+import os
+if os.getenv("ROS_VERSION", "1") != "2":
+    from . geneus_main import *

--- a/src/geneus/generate.py
+++ b/src/geneus/generate.py
@@ -40,9 +40,12 @@ import os
 import traceback
 import re
 
-from genmsg import SrvSpec, MsgSpec, MsgContext
-from genmsg.msg_loader import load_srv_from_file, load_msg_by_type
-import genmsg.gentools
+try: # Only for ROS 1
+    from genmsg import SrvSpec, MsgSpec, MsgContext
+    from genmsg.msg_loader import load_srv_from_file, load_msg_by_type
+    import genmsg.gentools
+except ImportError:
+    pass
 
 try:
     from cStringIO import StringIO #Python 2.x

--- a/test/test_import.py
+++ b/test/test_import.py
@@ -1,0 +1,33 @@
+"""Test that geneus modules and functions can be imported."""
+
+
+def test_import_geneus():
+    import geneus
+
+
+def test_import_generate_module():
+    from geneus import generate
+
+
+def test_import_type_check_function():
+    from geneus.generate import is_integer
+
+
+def test_import_type_conversion_function():
+    from geneus.generate import lisp_type
+
+
+def test_import_init_function():
+    from geneus.generate import lisp_initvalue
+
+
+def test_import_classes():
+    from geneus.generate import IndentedWriter, Indent
+
+
+def test_import_write_function():
+    from geneus.generate import write_serialize
+
+
+def test_import_generate_function():
+    from geneus.generate import generate_msg


### PR DESCRIPTION
We need to implement rosidl_generator_eus. There are so many useful functions in geneus, so we export this package as a library and import it from rosidl_generator_eus.
